### PR TITLE
Prepare for AICoE packaging

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,0 +1,3 @@
+check: []
+release:
+  - upload-pypi-sesheta

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Donkeycar is minimalist and modular self driving library for Python. It is
 developed for hobbyists and students with a focus on allowing fast experimentation and easy
 community contributions.
 
+NOTE: this package is a non-official build by the AICoE. Please check the upstream project links for official information.
+
 #### Quick Links
 * [Donkeycar Updates & Examples](http://donkeycar.com)
 * [Build instructions and Software documentation](http://docs.donkeycar.com)
 * [Discord / Chat](https://discord.gg/PN6kFeA)
-
-![donkeycar](./docs/assets/build_hardware/donkey2.png)
 
 #### Use Donkey if you want to:
 * Make an RC car drive its self.

--- a/donkeycar/__init__.py
+++ b/donkeycar/__init__.py
@@ -3,7 +3,7 @@ from pyfiglet import Figlet
 import logging
 from pkg_resources import get_distribution
 
-__version__ = get_distribution('donkeycar').version
+__version__ = "4.3.0"
 
 logging.basicConfig(level=logging.INFO)
 f = Figlet(font='speed')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 
 # include the non python files
@@ -13,6 +13,19 @@ def package_files(directory, strip_leading):
     return paths
 
 
+def get_version():
+    """Get version."""
+    with open(os.path.join("donkeycar", "__init__.py")) as f:
+        content = f.readlines()
+
+    for line in content:
+        if line.startswith("__version__ ="):
+            # dirty, remove trailing and leading chars
+            return line.split(" = ")[1][1:-2]
+
+    raise ValueError("No package version found")
+
+
 car_templates = ['templates/*']
 web_controller_html = package_files('donkeycar/parts/controllers/templates',
                                     'donkeycar/')
@@ -23,9 +36,11 @@ print('extra_files', extra_files)
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setup(name='donkeycar',
-      version="4.3.0",
+VERSION = get_version()
+setup(name='aicoe-donkeycar',
+      version=VERSION,
       long_description=long_description,
+      long_description_content_type="text/markdown",
       description='Self driving library for python.',
       url='https://github.com/autorope/donkeycar',
       author='Will Roscoe, Adam Conway, Tawn Kramer',
@@ -107,5 +122,7 @@ setup(name='donkeycar',
           'Programming Language :: Python :: 3.7',
       ],
       keywords='selfdriving cars donkeycar diyrobocars',
-      packages=find_packages(exclude=(['tests', 'docs', 'site', 'env'])),
-    )
+      packages=find_namespace_packages(
+          include=['donkeycar*'],
+          exclude=(['tests', 'docs', 'site', 'env']))
+      )


### PR DESCRIPTION
This PR is to set things up for packaging donkeycar and uploading to PyPI using aicoe-ci:

- Package name set to `aicoe-donkeycar`
- Add `.aicoe-ci.yaml`
- Add a note in the README mentioning that this is not an official package
- Version schema: keep upstream version and use post-releases, e.g. `4.3.0.post1`
- Replacing setuptools' `find_packages` with `find_namespace_packages` to include subpackages without `__init__.py`

