### PR TITLE
Set version to 4.3.0-1

### DIFF
--- a/donkeycar/__init__.py
+++ b/donkeycar/__init__.py
@@ -3,7 +3,7 @@ from pyfiglet import Figlet
 import logging
 from pkg_resources import get_distribution
 
-__version__ = "4.3.0.post1.dev2"
+__version__ = "4.3.0-1"
 
 logging.basicConfig(level=logging.INFO)
 f = Figlet(font='speed')


### PR DESCRIPTION
Set the version to `4.3.0-1`.

An idea/requirement here is to keep the upstream version, currently `4.3.0`, and do our modifications based upon that, being able to keep increasing our versions while still keeping the upstream version untouched.

In semver, `-1` refers to a **pre-release**, and it can be managed as such:

```
>>> semver.parse("1.2.3-1")
{'major': 1, 'minor': 2, 'patch': 3, 'prerelease': '1', 'build': None}
>>> semver.bump_prerelease("1.2.3-1")
'1.2.3-2'
```

In [PEP 440](https://www.python.org/dev/peps/pep-0440/), `-1` is actually interpreted as a **post-release** though. Therefore, the package gets built as `4.3.0.post1`.

This is a semantic discrepancy that I believe we will have to live with for the time being.

On the plus side: this discrepancy means that the resulting package is not considered a pre-release by `pip`, so it can be installed without `--pre`.

**NOTES**

The notation using `-N` is the only one syntactically compatible with both semver and PEP 440 (except they mean different things). See:

- https://semver.org/#spec-item-9 (semver pre-release syntax)
- https://www.python.org/dev/peps/pep-0440/#implicit-post-releases (PEP 440 post-release shortcut)


An alternative path that was considered were *build releases*  (identified with `+build.N` with semver). However, these would not meet our needs: PEP 440 considers these "local versions" and PyPI does not accept them for publication:

```
$ pipenv run python3 -m twine upload --repository testpypi dist/*
Uploading distributions to https://test.pypi.org/legacy/
Uploading aicoe_donkeycar-4.3.0+build.1-py3-none-any.whl
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 481k/481k [00:01<00:00, 341kB/s]
Error during upload. Retry with the --verbose option for more details.
HTTPError: 400 Bad Request from https://test.pypi.org/legacy/
'4.3.0+build.1' is an invalid value for Version. Error: Can't use PEP 440 local versions. See https://packaging.python.org/specifications/core-metadata for more information.
```
